### PR TITLE
update all-contributors badge to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # NumFOCUS Board of Directors & Technical Steering Committee Elections
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors-)
-
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+![All Contributors](https://img.shields.io/github/all-contributors/numfocus/elections?color=ee8449)
 
 <p>
     <b>English</b> |


### PR DESCRIPTION
It is better to use new version of all-contributors badge.
ref https://allcontributors.org/docs/en/bot/faq